### PR TITLE
base docker image is deprecated. Incorrect port is exposed.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dockerfile/java:oracle-java8
+FROM openjdk:8-jre
 
 MAINTAINER Marc Navarro https://github.com/morfeo8marc
 
@@ -16,7 +16,7 @@ RUN wget https://github.com/junegunn/redis-stat/releases/download/0.4.11/redis-s
 
 WORKDIR /redis-stat
 
-EXPOSE 8080
+EXPOSE 63790
 
 ADD run.sh /redis-stat/
 


### PR DESCRIPTION
There are two issues I want to update 

dockerfile/java:oracle-java8

is an outdated base image the modern docker hub images is 

openjdk:8-jre

When I test this change everything works as expected.

To test that image works as a http server I had to make a second change

when the http port is not specified the default is 63790 

I had to expose the correct port before I could see any output
